### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -59,7 +59,7 @@ def create_post_built_reading_set_file(input_directory, output_directory, filena
         for key in tqdm(reading_set.keys()):
             article_url = reading_set[key]['article_url']
             del reading_set[key]['article_url']
-            if article_url is not None and reading_set[key]['config'] is not "C":
+            if article_url is not None and reading_set[key]['config'] != "C":
                 if article_url not in article_url_to_content_mapping.keys():
                     topical_content_wapo_section = wapo_retriever.get_wapo_article_section(article_url)
                     article_url_to_content_mapping[article_url] = topical_content_wapo_section
@@ -73,7 +73,7 @@ def create_post_built_reading_set_file(input_directory, output_directory, filena
                                                'AS3': topical_content_wapo_section['AS3'],
                                                'AS4': topical_content_wapo_section['AS4']
                                                }
-            elif article_url is not None and reading_set[key]['config'] is "C" :
+            elif article_url is not None and reading_set[key]['config'] == "C" :
                 reading_set[key]['article'] = {'url': article_url}
             else:
                 reading_set[key]['article'] = {}


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. On n Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

[flake8](http://flake8.pycqa.org) testing of https://github.com/alexa/alexa-prize-topical-chat-dataset on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./src/build.py:62:44: F632 use ==/!= to compare str, bytes, and int literals
            if article_url is not None and reading_set[key]['config'] is not "C":
                                           ^
./src/build.py:76:46: F632 use ==/!= to compare str, bytes, and int literals
            elif article_url is not None and reading_set[key]['config'] is "C" :
                                             ^
2     F632 use ==/!= to compare str, bytes, and int literals
2
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
